### PR TITLE
refactor code for updated version of core

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject org.arachne-framework/hello-module "0.1.0"
+(defproject org.arachne-framework/hello-module "0.1.0-SNAPSHOT"
   :description "A minimal sample Arachne module"
   :dependencies [
                  ;; Scope "provided" means Clojure itself will be required, but not as a transitive dependency
                  [org.clojure/clojure "1.9.0-alpha12" :scope "provided"]
-                 [org.arachne-framework/arachne-core "0.1.0-master-0057-ad6d720"]]
+                 [org.arachne-framework/arachne-core "0.1.0-master-0062-a6074e6"]]
 
   ;; Use Arachne's development builds
   :repositories [["arachne-dev" "http://maven.arachne-framework.org/artifactory/arachne-dev"]]

--- a/src/arachne/hello.clj
+++ b/src/arachne/hello.clj
@@ -5,7 +5,7 @@
   implementation would all have their own namespaces, but here we will keep them
   together so it's possible to see all the parts at once."
   (:require [arachne.core.config :as cfg]
-            [arachne.core.config.ontology :as o]
+            [arachne.core.config.model :as m]
             [arachne.core.config.init :as dsl]
             [arachne.core.dsl.specs :as dslspecs]
             [com.stuartsierra.component :as c]
@@ -19,9 +19,9 @@
 (defn schema
   "Return the schema for the hello module"
   []
-  (o/class :arachne.hello/Greeter [:arachne.core/Component]
+  (m/type :arachne.hello/Greeter [:arachne.core/Component]
     "A greeter is a component that prints a greeting to System/out when the system is started."
-    (o/attr :arachne.hello.greeter/greeting :one :string
+    (m/attr :arachne.hello.greeter/greeting :one :string
       "The greeting that this greeter will use")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Refactored hello-module code to work with updated arachne-core, which now uses 'model' and 'type' instead of 'ontology' and 'class'.

Updated dependency in project.clj with new version of arachne-core.